### PR TITLE
change preloaders to preLoaders to make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This usually applies to ES6 module `import` statements, CSS `@import` at-rules, 
 ```js
 {
   module: {
-    preloaders: [{
+    preLoaders: [{
       test: /\.scss/,
       loader: 'import-glob-loader'
     }]


### PR DESCRIPTION
Apperently my webpack version doesn't support preloaders but expects it to be called preLoaders. For me as a webpack beginner, it took me time to find that issue.
