### PR TITLE
Fix parseQuery error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import loaderUtils from 'loader-utils';
 import glob from 'glob';
 
 export default function importGlob(source) {
-	const options = loaderUtils.parseQuery(this.query);
+	const options = (this.query === '' ? {} : loaderUtils.parseQuery(this.query));
 	// Default nodir to true
 	options.nodir = typeof options.nodir !== 'undefined' ? options.nodir : true;
 	options.cwd = this.context;


### PR DESCRIPTION
Fix Webpack 3 error with node versions different than 7.#.#.
The following error:
> Error: Module build failed: ModuleBuildError: Module build failed:
Error: A valid query string passed to parseQuery should begin with '?'

Same error here: https://github.com/jballant/webpack-strip-block/issues/4
Same fix: https://github.com/jballant/webpack-strip-block/pull/5/files#diff-168726dbe96b3ce427e7fedce31bb0bcR7